### PR TITLE
UX Change: Keep menu displayed regardless of type of text pulled in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,3 +82,6 @@ create-release-pr: create-merge-development-branch bump
 create-release-tag: checkout-main
 	git tag $(PACKAGE_VERSION)
 	git push origin $(PACKAGE_VERSION)
+
+create-gh-release:
+	gh release create -t v$(PACKAGE_VERSION) --notes-from-tag $(PACKAGE_VERSION)

--- a/cc-isearch-menu.el
+++ b/cc-isearch-menu.el
@@ -56,19 +56,19 @@
     ("s"
      "Pull next symbol or character from buffer"
      isearch-yank-symbol-or-char
-     :transient nil)
+     :transient t)
     ("l"
      "Pull rest of line from buffer"
      isearch-yank-line
-     :transient nil)
+     :transient t)
     ("y"
      "Pull string from kill ring"
      isearch-yank-kill
-     :transient nil)
+     :transient t)
     ("t"
      "Pull thing from buffer"
      isearch-forward-thing-at-point
-     :transient nil)]
+     :transient t)]
 
    ["Replace"
     ("r"


### PR DESCRIPTION
This changes all menu items that pull text to behave such that the menu is not
dismissed upon menu item selection.

Commands affected:

- isearch-yank-symbol-or-char
- isearch-yank-line
- isearch-yank-kill
- isearch-forward-thing-at-point

Also added Makefile target to create a GitHub release.
