### PR TITLE
Change toggle behavior to toggle and edit

### DIFF
--- a/cc-isearch-menu.el
+++ b/cc-isearch-menu.el
@@ -43,6 +43,24 @@
 
 (require 'transient)
 
+(defun cc-isearch--toggle-regex-and-edit ()
+  "Invoke `isearch-toggle-regexp' then `isearch-edit-string'."
+  (interactive)
+  (isearch-toggle-regexp)
+  (isearch-edit-string))
+
+(defun cc-isearch--toggle-symbol-and-edit ()
+  "Invoke `isearch-toggle-symbol' then `isearch-edit-string'."
+  (interactive)
+  (isearch-toggle-symbol)
+  (isearch-edit-string))
+
+(defun cc-isearch--toggle-word-and-edit ()
+  "Invoke `isearch-toggle-word' then `isearch-edit-string'."
+  (interactive)
+  (isearch-toggle-symbol)
+  (isearch-edit-string))
+
 (transient-define-prefix cc-isearch-menu-transient ()
   "Transient menu for isearch."
   [["Edit Search String"
@@ -85,16 +103,16 @@
 
   [["Toggle"
     ("X"
-     "Regexp searching"
-     isearch-toggle-regexp
+     "Regexp searching (edit)"
+     cc-isearch--toggle-regex-and-edit
      :transient t)
     ("S"
-     "Symbol searching"
-     isearch-toggle-symbol
+     "Symbol searching (edit)"
+     cc-isearch--toggle-symbol-and-edit
      :transient t)
     ("W"
-     "Word searching"
-     isearch-toggle-word
+     "Word searching (edit)"
+     cc-isearch--toggle-word-and-edit
      :transient t)
     ("F"
      "Case fold"


### PR DESCRIPTION
Change isearch toggle behavior to support editing for the following operations:
- regexp
- symbol
- word

Note that "case fold" and "lax whitespace" do not invoke editing.
