### PR TITLE
Change isearch-forward-thing-at-point transient behavior to nil

### DIFF
--- a/cc-isearch-menu.el
+++ b/cc-isearch-menu.el
@@ -87,7 +87,7 @@
     ("t"
      "Pull thing from buffer"
      isearch-forward-thing-at-point
-     :transient t)]
+     :transient nil)]
 
    ["Replace"
     ("r"


### PR DESCRIPTION
This is a patch fix to avoid causing an inconsistent transient state error when
calling isearch-forward-thing-at-point then calling another command such as
isearch-query-replace when the menu is still raised.
