### PR TITLE
Merge development to main 20240331_174802

### DIFF
--- a/cc-isearch-menu.el
+++ b/cc-isearch-menu.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/cc-isearch-menu
 ;; Keywords: wp
-;; Version: 1.4.0
+;; Version: 1.4.1
 ;; Package-Requires: ((emacs "29.1"))
 ;;
 


### PR DESCRIPTION
- **Change isearch-forward-thing-at-point transient behavior to nil**
  This is a patch fix to avoid causing an inconsistent transient state error when
  calling isearch-forward-thing-at-point then calling another command such as
  isearch-query-replace when the menu is still raised.
  

- **Bump version to 1.4.1**
  